### PR TITLE
v1.2.0: widen peer deps, fix self-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-core-responsive-screen",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "description": "react-native-core-responsive-screen is a small library that provides 2 simple methods so that React Native developers can code their UI elements fully responsive. No media queries needed. It also provides an optional third method for screen orientation detection and automatic rerendering according to new dimensions",
   "main": "index.js",
   "scripts": {
@@ -27,9 +27,7 @@
   },
   "homepage": "https://github.com/Utkarshsingh001/react-native-core-responsive-screen#readme",
   "peerDependencies": {
-    "react-native": "^0.74.3"
-  },
-  "dependencies": {
-    "react-native-core-responsive-screen": "^1.0.0"
+    "react": ">=17.0.0",
+    "react-native": ">=0.60.0"
   }
 }


### PR DESCRIPTION
- Widen react-native peer range from ^0.74.3 (which blocked RN 0.75+) to >=0.60.0; the lib only uses Dimensions, PixelRatio and StyleSheet
- Declare react >=17.0.0 as a peer dependency (hooks are imported from it)
- Remove accidental self-dependency from dependencies